### PR TITLE
Pull Request: Fix Python Package Installation on macOS (M2) Runner

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -253,11 +253,15 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
-    - name: dependencies
-      run: pip3 install --break-system-packages mako && brew install orc
-    - name: configure
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with: 
+        python-version: '3.x'
+    - name: Install dependencies
+      run: pip install mako && brew install orc
+    - name: Configure
       run: mkdir build && cd build && cmake -DBUILD_EXECUTABLE=ON ..
-    - name: build
+    - name: Build
       run: cmake --build build --config Debug -j3
     - name: Print info
       run: |


### PR DESCRIPTION
### Pull Request: Fix Python Package Installation on macOS (M2) Runner

#### Summary:
There is a minor challenge when attempting to install Python packages, specifically `mako`, in your CI/CD workflow running on a macOS (M2) runner provided by FlyCI. The root of the issue was the Python environment being marked as "externally managed," which effectively prevented `pip` from installing packages without utilizing special flags. This behavior was notably absent on GitHub Actions' `macos-latest` runner, which is Intel-based, underscoring a distinct handling of Python environments across different architectures and CI services.

#### Issue Description:
The problem manifested as an error during the package installation phase, blocking the `pip` command due to the environment's externally managed status. This restriction aims to safeguard the system's integrity by preventing package installations that could potentially conflict with system-managed packages. However, it also introduced hurdles for your CI/CD process, necessitating a workaround to maintain your workflow's functionality across varying CI environments and architectures.

#### Implemented Solution:
To address and overcome this challenge, we made several pivotal changes to your workflow configuration:

1. **Integration of `actions/setup-python`**:
   - Added the `actions/setup-python` action to your workflow steps before any Python package installations. This step is crucial for correctly setting up Python, ensuring a stable and compatible environment for package management across different operating systems and architectures, thereby mitigating potential conflicts with system-managed packages.

2. **Direct Installation of Packages**:
   - Utilized the `pip install mako` command directly, without the `--break-system-packages` flag, post the `setup-python` action. This approach relies on the assumption that the setup action prepares an environment where bypassing system package management safeguards is unnecessary, reducing the associated risks.

3. **Removal of Unnecessary Flags**:
   - Removed the `--break-system-packages` flag from the installation command. This flag was initially used to force package installations in an externally managed environment but was deemed unnecessary and potentially risky after the Python environment had been correctly set up. Additionally, it was clarified that this flag was inapplicable to the `brew install orc` command, as `brew` functions independently of Python's package management.

#### Impact:
By implementing these changes, your workflow is now better positioned to manage Python packages reliably across different CI environments and architectures. These adjustments help minimize the risk of conflicts with system packages and bolster the stability and reproducibility of your build process, ensuring a smoother and more efficient CI/CD pipeline.